### PR TITLE
Store debug information to the log

### DIFF
--- a/Code/ChroniclerJ/src/edu/columbia/cs/psl/chroniclerj/ChroniclerJExportRunner.java
+++ b/Code/ChroniclerJ/src/edu/columbia/cs/psl/chroniclerj/ChroniclerJExportRunner.java
@@ -149,6 +149,7 @@ public class ChroniclerJExportRunner extends Thread {
             ExportedLog.aLog = Log.aLog;
             ExportedLog.aLog_owners = Log.aLog_owners;
             ExportedLog.aLog_fill = Log.aLog_fill;
+            ExportedLog.aLog_debug = Log.aLog_debug;
             Log.logsize = 0;
             Log.aLog = new Object[Constants.DEFAULT_LOG_SIZE];
             Log.aLog_fill = 0;
@@ -211,6 +212,16 @@ public class ChroniclerJExportRunner extends Thread {
                 ExportedSerializableLog.cLog_owners = SerializableLog.cLog_owners;
                 ExportedSerializableLog.sLog_owners = SerializableLog.sLog_owners;
 
+                ExportedSerializableLog.aLog_debug = SerializableLog.aLog_debug;
+                ExportedSerializableLog.iLog_debug = SerializableLog.iLog_debug;
+                ExportedSerializableLog.jLog_debug = SerializableLog.jLog_debug;
+                ExportedSerializableLog.fLog_debug = SerializableLog.fLog_debug;
+                ExportedSerializableLog.dLog_debug = SerializableLog.dLog_debug;
+                ExportedSerializableLog.bLog_debug = SerializableLog.bLog_debug;
+                ExportedSerializableLog.zLog_debug = SerializableLog.zLog_debug;
+                ExportedSerializableLog.cLog_debug = SerializableLog.cLog_debug;
+                ExportedSerializableLog.sLog_debug = SerializableLog.sLog_debug;
+                
                 SerializableLog.aLog = new Object[Constants.DEFAULT_LOG_SIZE];
                 SerializableLog.iLog = new int[Constants.DEFAULT_LOG_SIZE];
                 SerializableLog.jLog = new long[Constants.DEFAULT_LOG_SIZE];
@@ -229,6 +240,15 @@ public class ChroniclerJExportRunner extends Thread {
                 SerializableLog.zLog_owners = new String[Constants.DEFAULT_LOG_SIZE];
                 SerializableLog.cLog_owners = new String[Constants.DEFAULT_LOG_SIZE];
                 SerializableLog.sLog_owners = new String[Constants.DEFAULT_LOG_SIZE];
+                SerializableLog.aLog_debug = new String[Constants.DEFAULT_LOG_SIZE];
+                SerializableLog.iLog_debug = new String[Constants.DEFAULT_LOG_SIZE];
+                SerializableLog.jLog_debug = new String[Constants.DEFAULT_LOG_SIZE];
+                SerializableLog.fLog_debug = new String[Constants.DEFAULT_LOG_SIZE];
+                SerializableLog.dLog_debug = new String[Constants.DEFAULT_LOG_SIZE];
+                SerializableLog.bLog_debug = new String[Constants.DEFAULT_LOG_SIZE];
+                SerializableLog.zLog_debug = new String[Constants.DEFAULT_LOG_SIZE];
+                SerializableLog.cLog_debug = new String[Constants.DEFAULT_LOG_SIZE];
+                SerializableLog.sLog_debug = new String[Constants.DEFAULT_LOG_SIZE];
                 SerializableLog.logsize = 0;
                 SerializableLog.iLog_fill = 0;
                 SerializableLog.jLog_fill = 0;

--- a/Code/ChroniclerJ/src/edu/columbia/cs/psl/chroniclerj/ExportedLog.java
+++ b/Code/ChroniclerJ/src/edu/columbia/cs/psl/chroniclerj/ExportedLog.java
@@ -3,11 +3,15 @@ package edu.columbia.cs.psl.chroniclerj;
 
 import java.util.HashMap;
 
+
 public class ExportedLog {
     public static Object[] aLog = new Object[Constants.DEFAULT_LOG_SIZE];
 
     public static String[] aLog_owners = new String[Constants.DEFAULT_LOG_SIZE];
 
+    public static String[] aLog_debug = new String[Constants.DEFAULT_LOG_SIZE];
+
+    
     public static int aLog_fill;
 
     public static int globalReplayIndex = 0;
@@ -17,6 +21,7 @@ public class ExportedLog {
     public static void clearLog() {
         aLog = new Object[Constants.DEFAULT_LOG_SIZE];
         aLog_owners = new String[Constants.DEFAULT_LOG_SIZE];
+        aLog_debug = new String[Constants.DEFAULT_LOG_SIZE];
         aLog_fill = 0;
         globalReplayIndex = 0;
     }

--- a/Code/ChroniclerJ/src/edu/columbia/cs/psl/chroniclerj/ExportedSerializableLog.java
+++ b/Code/ChroniclerJ/src/edu/columbia/cs/psl/chroniclerj/ExportedSerializableLog.java
@@ -71,10 +71,30 @@ public class ExportedSerializableLog implements Serializable {
     public static String[] cLog_owners = new String[Constants.DEFAULT_LOG_SIZE];
 
     public static String[] sLog_owners = new String[Constants.DEFAULT_LOG_SIZE];
+    
+    public static String[] aLog_debug = new String[Constants.DEFAULT_LOG_SIZE];
+
+    public static String[] iLog_debug = new String[Constants.DEFAULT_LOG_SIZE];
+
+    public static String[] jLog_debug = new String[Constants.DEFAULT_LOG_SIZE];
+
+    public static String[] fLog_debug = new String[Constants.DEFAULT_LOG_SIZE];
+
+    public static String[] dLog_debug = new String[Constants.DEFAULT_LOG_SIZE];
+
+    public static String[] bLog_debug = new String[Constants.DEFAULT_LOG_SIZE];
+
+    public static String[] zLog_debug = new String[Constants.DEFAULT_LOG_SIZE];
+
+    public static String[] cLog_debug = new String[Constants.DEFAULT_LOG_SIZE];
+
+    public static String[] sLog_debug = new String[Constants.DEFAULT_LOG_SIZE];
 
     public static void clearLog() {
         aLog = new Serializable[Constants.DEFAULT_LOG_SIZE];
         aLog_fill = 0;
+        aLog_owners = new String[Constants.DEFAULT_LOG_SIZE];
+        aLog_debug = new String[Constants.DEFAULT_LOG_SIZE];
     }
 
     private void writeObject(ObjectOutputStream oos) throws IOException {
@@ -107,6 +127,16 @@ public class ExportedSerializableLog implements Serializable {
         oos.writeObject(zLog_owners);
         oos.writeObject(cLog_owners);
         oos.writeObject(sLog_owners);
+        
+        oos.writeObject(aLog_debug);
+        oos.writeObject(iLog_debug);
+        oos.writeObject(jLog_debug);
+        oos.writeObject(fLog_debug);
+        oos.writeObject(dLog_debug);
+        oos.writeObject(bLog_debug);
+        oos.writeObject(zLog_debug);
+        oos.writeObject(cLog_debug);
+        oos.writeObject(sLog_debug);
 
     }
 
@@ -140,6 +170,16 @@ public class ExportedSerializableLog implements Serializable {
         zLog_owners = (String[]) ois.readObject();
         cLog_owners = (String[]) ois.readObject();
         sLog_owners = (String[]) ois.readObject();
+        
+        aLog_debug = (String[]) ois.readObject();
+        iLog_debug = (String[]) ois.readObject();
+        jLog_debug = (String[]) ois.readObject();
+        fLog_debug = (String[]) ois.readObject();
+        dLog_debug = (String[]) ois.readObject();
+        bLog_debug = (String[]) ois.readObject();
+        zLog_debug = (String[]) ois.readObject();
+        cLog_debug = (String[]) ois.readObject();
+        sLog_debug = (String[]) ois.readObject();
 
         ExportedSerializableLog.aLog_replayIndex = new HashMap<String, Integer>();
         ExportedSerializableLog.iLog_replayIndex = new HashMap<String, Integer>();

--- a/Code/ChroniclerJ/src/edu/columbia/cs/psl/chroniclerj/Instrumenter.java
+++ b/Code/ChroniclerJ/src/edu/columbia/cs/psl/chroniclerj/Instrumenter.java
@@ -55,7 +55,7 @@ public class Instrumenter {
 
     private static final int PASS_OUTPUT = 1;
 
-    public static final boolean IS_DACAPO = true;
+    public static final boolean IS_DACAPO = false;
 
     private static int pass_number = 0;
 

--- a/Code/ChroniclerJ/src/edu/columbia/cs/psl/chroniclerj/Log.java
+++ b/Code/ChroniclerJ/src/edu/columbia/cs/psl/chroniclerj/Log.java
@@ -9,6 +9,9 @@ public class Log {
 
     public static String[] aLog_owners = new String[Constants.DEFAULT_LOG_SIZE];
 
+    public static String[] aLog_debug = new String[Constants.DEFAULT_LOG_SIZE];
+
+    
     public static Lock logLock = new ReentrantLock();
 
     public static int logsize = 0;
@@ -21,6 +24,7 @@ public class Log {
         logsize = 0;
         aLog = new Object[Constants.DEFAULT_LOG_SIZE];
         aLog_owners = new String[Constants.DEFAULT_LOG_SIZE];
+        aLog_debug = new String[Constants.DEFAULT_LOG_SIZE];
 
         aLog_fill = 0;
 

--- a/Code/ChroniclerJ/src/edu/columbia/cs/psl/chroniclerj/SerializableLog.java
+++ b/Code/ChroniclerJ/src/edu/columbia/cs/psl/chroniclerj/SerializableLog.java
@@ -43,6 +43,24 @@ public class SerializableLog implements Serializable {
 
     public static String[] sLog_owners = new String[Constants.DEFAULT_LOG_SIZE];
 
+    public static String[] aLog_debug = new String[Constants.DEFAULT_LOG_SIZE];
+
+    public static String[] iLog_debug = new String[Constants.DEFAULT_LOG_SIZE];
+
+    public static String[] jLog_debug = new String[Constants.DEFAULT_LOG_SIZE];
+
+    public static String[] fLog_debug = new String[Constants.DEFAULT_LOG_SIZE];
+
+    public static String[] dLog_debug = new String[Constants.DEFAULT_LOG_SIZE];
+
+    public static String[] bLog_debug = new String[Constants.DEFAULT_LOG_SIZE];
+
+    public static String[] zLog_debug = new String[Constants.DEFAULT_LOG_SIZE];
+
+    public static String[] cLog_debug = new String[Constants.DEFAULT_LOG_SIZE];
+
+    public static String[] sLog_debug = new String[Constants.DEFAULT_LOG_SIZE];
+
     public static int logsize = 0;
 
     public static int aLog_fill, iLog_fill, jLog_fill, fLog_fill, dLog_fill, bLog_fill, zLog_fill,

--- a/Code/ChroniclerJ/src/edu/columbia/cs/psl/chroniclerj/bench/ChroniclerJLogExplorer.java
+++ b/Code/ChroniclerJ/src/edu/columbia/cs/psl/chroniclerj/bench/ChroniclerJLogExplorer.java
@@ -7,29 +7,25 @@ import java.io.ObjectInputStream;
 import java.util.Arrays;
 
 import edu.columbia.cs.psl.chroniclerj.ExportedSerializableLog;
+import edu.columbia.cs.psl.chroniclerj.replay.ReplayRunner;
 
 public class ChroniclerJLogExplorer {
     @SuppressWarnings({
             "resource", "unused"
     })
     public static void main(String[] args) throws Exception {
-        File f = new File("../chroniclerj-test/inst-bin/chroniclerj_serializable_1362003992533.log");
+        File f = new File(args[0]);
         if (!f.exists())
-            System.err.println("No such fiel");
-        ObjectInputStream ois = new ObjectInputStream(new FileInputStream(f));
-        ExportedSerializableLog log = (ExportedSerializableLog) ois.readObject();
-        Object[] alog = ExportedSerializableLog.aLog;
-
-        char[] clog = ExportedSerializableLog.cLog;
-        byte[] blog = ExportedSerializableLog.bLog;
-        String[] ownersA = ExportedSerializableLog.aLog_owners;
-        String[] ownersI = ExportedSerializableLog.iLog_owners;
-        System.out.println(ExportedSerializableLog.aLog_fill);
-        System.out.println(ExportedSerializableLog.cLog_fill);
-        System.out.println(ExportedSerializableLog.dLog_fill);
-        double[] dlog = ExportedSerializableLog.dLog;
-        String[] ownersD = ExportedSerializableLog.dLog_owners;
-        System.out.println(Arrays.toString(dlog));
-        System.out.println(Arrays.toString(ownersD));
-    }
+            System.err.println("No such file");
+        String[] cp = System.getProperty("java.class.path").split(System.getProperty("path.separator"));
+        String[] cp2 = new String[cp.length+1];
+        cp2[0] = f.getAbsolutePath();
+        System.arraycopy(cp, 0, cp2, 1, cp.length);
+        ReplayRunner.setupLogs(cp2);
+        System.out.println("Log of longs:");
+        for(int i = 0; i < ExportedSerializableLog.jLog_fill; i++)
+        {
+        	System.out.println("Entry " + i + " value: " + ExportedSerializableLog.jLog[i] + ", debug:" + ExportedSerializableLog.jLog_debug[i]);
+        }
+   }
 }

--- a/Code/ChroniclerJ/src/edu/columbia/cs/psl/chroniclerj/replay/ReplayRunner.java
+++ b/Code/ChroniclerJ/src/edu/columbia/cs/psl/chroniclerj/replay/ReplayRunner.java
@@ -78,8 +78,11 @@ public class ReplayRunner {
 
     private static URLClassLoader loader = null;
 
-    public static void _main(String[] classpath) {
-        if (!new File(classpath[0]).exists()) {
+    static String mainClass;
+    static String[] params;
+    public static void setupLogs(String[] classpath)
+    {
+    	if (!new File(classpath[0]).exists()) {
             System.err.println("Unable to load test case " + classpath[0]);
             System.exit(-1);
         }
@@ -97,11 +100,11 @@ public class ReplayRunner {
         InputStream inputStream = loader.getResourceAsStream("main-info");
 
         Scanner s = new Scanner(inputStream);
-        String mainClass = s.nextLine();
+        mainClass = s.nextLine();
         ArrayList<String> _serializableLogs = new ArrayList<String>();
         ArrayList<String> _logs = new ArrayList<String>();
         int nArgs = Integer.parseInt(s.nextLine());
-        String[] params = new String[nArgs];
+        params = new String[nArgs];
         int nSerializableLogs = 0;
 
         int nLogs = 0;
@@ -131,6 +134,9 @@ public class ReplayRunner {
         _loadNextLog(Type.getDescriptor(ExportedSerializableLog.class));
 
         _loadNextLog(Type.getDescriptor(ExportedLog.class));
+    }
+    public static void _main(String[] classpath) {
+        setupLogs(classpath);
         ReplayUtils.checkForDispatch();
         Class<?> toRun;
         try {

--- a/Code/ChroniclerJ/src/edu/columbia/cs/psl/chroniclerj/visitor/CloningAdviceAdapter.java
+++ b/Code/ChroniclerJ/src/edu/columbia/cs/psl/chroniclerj/visitor/CloningAdviceAdapter.java
@@ -290,6 +290,32 @@ public class CloningAdviceAdapter extends GeneratorAdapter implements Opcodes {
 
         loadLocal(newArray2);
         visitFieldInsn(putOpcode, logFieldOwner, logFieldName + "_owners", "[Ljava/lang/String;");
+        
+        
+        int newArray3 = lvsorter.newLocal(Type.getType("[Ljava/lang/String;"));
+        visitFieldInsn(getOpcode, logFieldOwner, logFieldName + "_debug", "[Ljava/lang/String;");
+        arrayLength();
+        visitInsn(Opcodes.I2D);
+        visitLdcInsn(Constants.LOG_GROWTH_RATE);
+        visitInsn(Opcodes.DMUL);
+        visitInsn(Opcodes.D2I);
+
+        newArray(Type.getType("Ljava/lang/String;"));
+
+        storeLocal(newArray3, Type.getType("[Ljava/lang/String;"));
+        visitFieldInsn(getOpcode, logFieldOwner, logFieldName + "_debug", "[Ljava/lang/String;");
+        visitInsn(Opcodes.ICONST_0);
+        loadLocal(newArray3);
+        visitInsn(Opcodes.ICONST_0);
+        visitFieldInsn(getOpcode, logFieldOwner, logFieldName + "_debug", "[Ljava/lang/String;");
+        arrayLength();
+        visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/System", "arraycopy",
+                "(Ljava/lang/Object;ILjava/lang/Object;II)V");
+
+        // array = newarray
+
+        loadLocal(newArray3);
+        visitFieldInsn(putOpcode, logFieldOwner, logFieldName + "_debug", "[Ljava/lang/String;");
 
         visitLabel(labelForNoNeedToGrow);
         // Load this into the end piece of the array
@@ -341,6 +367,13 @@ public class CloningAdviceAdapter extends GeneratorAdapter implements Opcodes {
 
         arrayStore(elementType);
 
+        visitFieldInsn(getOpcode, logFieldOwner, logFieldName + "_debug", "[Ljava/lang/String;");
+        visitFieldInsn(getOpcode, logFieldOwner, logFieldName + "_fill",
+                Type.INT_TYPE.getDescriptor());
+        visitLdcInsn(debug);
+        arrayStore(Type.getType(String.class));
+
+        
         visitFieldInsn(getOpcode, logFieldOwner, logFieldName + "_owners", "[Ljava/lang/String;");
         visitFieldInsn(getOpcode, logFieldOwner, logFieldName + "_fill",
                 Type.INT_TYPE.getDescriptor());


### PR DESCRIPTION
Store debug information (source of log entry) to log. Simple tool to show log at edu.columbia.cs.psl.chroniclerj.bench.ChroniclerJLogExplorer